### PR TITLE
Fix Orphan Children

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,17 +1,6 @@
-begin
-  require 'bundler/setup'
-rescue LoadError
-  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
-end
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
 
-require 'bundler/gem_tasks'
+RSpec::Core::RakeTask.new(:spec)
 
-require 'rspec'
-require 'rspec/core/rake_task'
-
-RSpec::Core::RakeTask.new(:spec) do |t|
-  t.rspec_opts = "-I #{File.expand_path('../spec/', __FILE__)}"
-  t.pattern =  File.expand_path('../spec/**/*_spec.rb', __FILE__)
-end
-
-task(default: :spec)
+task :default => :spec

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,17 @@
-require "bundler/gem_tasks"
+begin
+  require 'bundler/setup'
+rescue LoadError
+  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+end
+
+require 'bundler/gem_tasks'
+
+require 'rspec'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.rspec_opts = "-I #{File.expand_path('../spec/', __FILE__)}"
+  t.pattern =  File.expand_path('../spec/**/*_spec.rb', __FILE__)
+end
+
+task(default: :spec)

--- a/lib/csv_row_model/concerns/import/base.rb
+++ b/lib/csv_row_model/concerns/import/base.rb
@@ -74,8 +74,11 @@ module CsvRowModel
                               previous: file.previous_row_model)
 
             return row_model if csv.end_of_file?
-
-            next_row_is_parent = !row_model.append_child(csv.next_row)
+            
+            child_row_model = row_model.append_child(csv.next_row)
+            # Is a next parent when there is no children left 
+            # or if the next row match a invalid child but a valid parent 
+            next_row_is_parent = child_row_model.nil? || (!child_row_model.child? && child_row_model.valid?)
             return row_model if next_row_is_parent
           end
         end

--- a/lib/csv_row_model/concerns/import/base.rb
+++ b/lib/csv_row_model/concerns/import/base.rb
@@ -76,7 +76,7 @@ module CsvRowModel
             return row_model if csv.end_of_file?
             
             child_row_model = row_model.append_child(csv.next_row)
-            # Is a next parent when there is no children left 
+            # Is a Next Parent when there are no children left 
             # or if the next row match a invalid child but a valid parent 
             next_row_is_parent = child_row_model.nil? || (!child_row_model.child? && child_row_model.valid?)
             return row_model if next_row_is_parent

--- a/lib/csv_row_model/concerns/model/children.rb
+++ b/lib/csv_row_model/concerns/model/children.rb
@@ -27,6 +27,8 @@ module CsvRowModel
           if child_row_model.valid?
             public_send(relation_name) << child_row_model
             return child_row_model
+          else
+            return self.class.new(source, options)
           end
         end
         nil

--- a/spec/csv_row_model/concerns/model/children_spec.rb
+++ b/spec/csv_row_model/concerns/model/children_spec.rb
@@ -50,11 +50,14 @@ describe CsvRowModel::Model::Children do
         end
 
         context "when child is invalid" do
-          before { allow(another_instance).to receive(:valid?).and_return(false) }
+          before do
+            allow(BasicRowModel).to receive(:new).with(source_row, {}).and_return instance
+            allow(another_instance).to receive(:valid?).and_return(false)
+          end 
 
           it "doesn't append the child and returns nil" do
-            expect(subject).to eql nil
-            expect(parent_instance.children).to eql [instance]
+            expect(subject).to_not be_child
+            expect(parent_instance.children).to eql [parent_instance]
           end
         end
       end

--- a/spec/csv_row_model/public/export/file_spec.rb
+++ b/spec/csv_row_model/public/export/file_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'tempfile'
 
 describe CsvRowModel::Export::File do
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,7 @@
-Bundler.require(:default, :test)
-CodeClimate::TestReporter.start
-
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'csv_row_model'
 
+require Dir.pwd + '/spec/support/shared_context/with_context.rb'
 Dir[Dir.pwd + '/spec/support/**/*.rb'].each { |f| require f }
 
 RSpec.configure do |c|


### PR DESCRIPTION
Hi Steve!

[Group](https://github.com/FinalCAD/csv_row_model/issues/70) may an interesting feature in a certain case; however, in children case, it doesn't fit the use-case. 
  
Relying on Child Validations to detect the new parent it's the halfway to do so. Let's take a look at the following simple sample:

```  
create_table(:contact_books) do |t|
  t.string :name
end

create_table(:users) do |t|
  t.string :first_name
  t.string :last_name
  t.string :email
  t.references :contact_book
end

class ContactBookImportRow
  include CsvRowModel::Model
  
  column :book_name
      
  include CsvRowModel::Import
  
  validates :book_name, presence: true
  
  represents_one :contact_book, dependencies: %i(book_name) do
    ContactBook.first_or_create(name: book_name)
  end
  
  has_many :users, UserImportRow
end 


class UserImportRow
  include CsvRowModel::Model

    column :email, parse: ->(email) { email.downcase }
    column :first_name
    column :last_name

  include CsvRowModel::Import
  
  validates :email, presence: true
  
  represents_one :user, dependencies: %i(email) do
    user = User.find_or_create(email: email)
    user.update(attributes.except(:email))
    user
  end
end 

[
  [ 'Book Name' , 'Email'                          , 'First Name', 'Last Name' ],
  [ 'Perso'     , ''                               , ''          , ''          ],
  [ ''          , 'cherry.howe@lesch.com'          , 'Cherry'    , 'Howe'      ],
  [ ''          , ''                               , 'Joel'      , 'AZEMAR'    ], # Will invalid and return the RowModel
  [ ''          , 'palmer.kiehn@fay.ca'            , 'Palmer'    , 'Kiehn'     ], # Will be invalid as a parent and ignored 
  [ ''          , 'laree.crist@reynolds.com'       , 'Laree'     , 'Crist'     ], # Will be invalid as a parent and ignored 
  [ 'Pro'       , ''                               , ''          , ''          ],
  [ ''          , 'judith.gibson@hoeger.co.uk'     , 'Judith'    , 'Gibson'    ],
  [ ''          , 'krishna.keebler@wuckerthoppe.us', 'Krishna'   , 'Keebler'   ],
]

let!(:importer) { CsvRowModel::Import::File.new(file.path, row_model_class, context) }
let(:rows)      {[]}
        
while (row = importer.next) do 
  if row.valid? and row.is_a?(ContactBookImportRow)
    rows << row
  end
end

it { expect(rows.size).to eql(2) }

context 'row 1' do
  it do
    expect(rows[0].contact_book.name).to eql('Perso')
    expect(
      rows[0].users.map { |user_import_row| user_import_row.user.name }.sort
    ).to eql(["Cherry Howe"]) # two orphan here
  end
end

context 'row 2' do
  it do
    expect(rows[1].contact_book.name).to eql('Pro')
    expect(
      rows[1].users.map { |user_import_row| user_import_row.user.name }.sort
    ).to eql(["Judith Gibson", "Krishna Keebler"])
  end
end 
```

A quick workaround would be considered `next_row_is_parent` only when the child is invalid, AND the parent is valid, rely on validations as a pattern for the parent row.

What are your thoughts?




